### PR TITLE
Feature | Admin is able to create account, log in and log out

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,8 +14,11 @@
       <%= f.input :address,
                   required: true,
                   autofocus: true%>
-    <% end %>  
-    <%= request.path %>          
+    <% else %>
+      <%= f.input :phone,
+                  required: true,
+                  autofocus: true%>
+    <% end %>          
     <%= f.input :email,
                 required: true,
                 autofocus: true,

--- a/db/migrate/20210804051523_devise_create_admins.rb
+++ b/db/migrate/20210804051523_devise_create_admins.rb
@@ -9,6 +9,7 @@ class DeviseCreateAdmins < ActiveRecord::Migration[6.1]
       t.string :first_name
       t.string :last_name
       t.string :phone
+      
       t.decimal :earnings
       ## Recoverable
       t.string   :reset_password_token


### PR DESCRIPTION
Sellers can create an account. Name, phone, email and password are required to create an account.

- Seller model was replaced with Admin devise model. Database updated.
- Configure view so that it asks Admin for phone instead of address (like the user).
- Admin can now log in, log out and sign up.